### PR TITLE
make cf routes hyperlinks use https instead of http

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
@@ -262,7 +262,7 @@ export class ApplicationService {
         return nonTCPRoutes[0] || null;
       }),
       map(entRoute => !!entRoute && !!entRoute && !!entRoute.domain ?
-        getRoute(entRoute.port, entRoute.host, entRoute.path, true, false, entRoute.domain.name) :
+        getRoute(entRoute.port, entRoute.host, entRoute.path, true, true, entRoute.domain.name) :
         null
       )
     );

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/cf-routes-data-source-base.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/cf-routes-data-source-base.ts
@@ -88,7 +88,7 @@ export abstract class CfRoutesDataSourceBase extends CFListDataSource<APIResourc
           }
           const entity: ListCfRoute = {
             ...route.entity,
-            url: getRoute(route.entity.port, route.entity.host, route.entity.path, true, false, route.entity.domain.entity.name),
+            url: getRoute(route.entity.port, route.entity.host, route.entity.path, true, true, route.entity.domain.entity.name),
             isTCPRoute: isTCPRoute(route.entity.port)
           };
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/table-cell-route/table-cell-route.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/table-cell-route/table-cell-route.component.ts
@@ -18,7 +18,7 @@ export class TableCellRouteComponent extends TableCellCustom<APIResource<ListCfR
     const route = this.row.entity;
     if (route) {
       this.isRouteTCP = isTCPRoute(route.port);
-      this.routeUrl = getRoute(route.port, route.host, route.path, !this.isRouteTCP, false, route.domain.entity.name);
+      this.routeUrl = getRoute(route.port, route.host, route.path, !this.isRouteTCP, true, route.domain.entity.name);
     }
   }
 }


### PR DESCRIPTION
make cf routes hyperlinks use https instead of http

## Description
The current list of routes (Applications => <pick app> => Routes ), have hyperlinks using http, I think we should make these https.

## Motivation and Context
Using https is the default nowadays.

## How Has This Been Tested?
This has been running for about a year in all our CF environments, where we used our own fork of Stratos (github.com/rabobank/stratos).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Change behaviour, make it more secure

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message