### PR TITLE
Fix environment variables GUI for new apps

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -74,7 +74,7 @@ export class VariablesTabComponent implements OnInit {
       if (envVarType === 'cfGuid' || envVarType === stratosEndpointGuidKey) {
         return;
       }
-      const envVars = allEnvVars[0].entity[envVarType];
+      const envVars = (allEnvVars[0].entity[envVarType]) ? allEnvVars[0].entity[envVarType] : {};
       result.push({
         section: true,
         name: envVarType.replace('_json', ''),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-variables/cf-app-variables-data-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-variables/cf-app-variables-data-source.ts
@@ -44,7 +44,7 @@ export class CfAppVariablesDataSource extends ListDataSource<ListAppEnvVar, APIR
         if (!variables || variables.length === 0) {
           return [];
         }
-        const env = variables[0].entity.environment_json;
+        const env = (variables[0].entity.environment_json) ? variables[0].entity.environment_json : {};
         const rows = Object.keys(env).map(name => ({ name, value: env[name] }));
         return rows;
       }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request addresses a bug in the Stratos GUI that caused issues with displaying and managing environment variables for new applications in the GUI. 
The fix ensures that the environment variables object is not NULL and provides an empty object if necessary.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a new app was created, the environment variables were not shown correctly.
This was caused by a NULL entry. 
The entry prevented the GUI from displaying the environment variables correctly because it had nothing to iterate over.
It also prevented the setting of new variables and prevented variables that were set manually from being shown.
This was solved by inserting an empty object if the variable is currently set to NULL.  

## How Has This Been Tested?
This fix has been running on the STACKIT Stratos for two years.
It was manually tested by creating a new application and testing that the env variables were shown correctly and were editable in the GUI. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message