### PR TITLE
Fix: Default app name on 'About' page is always 'Zuun'

### DIFF
--- a/src/frontend/packages/core/src/app.module.ts
+++ b/src/frontend/packages/core/src/app.module.ts
@@ -257,7 +257,6 @@ export class AppModule {
     );
 
     customizationService.setAppNameFromTitle();
-    customizationService.get().appName = 'Zuun';
   }
 
   private syncFavorite(favorite: UserFavorite<IFavoriteMetadata>, entities: GeneralRequestDataState) {

--- a/website/docs/extensions/frontend.md
+++ b/website/docs/extensions/frontend.md
@@ -266,6 +266,7 @@ A customization service provides a number of smaller extension points.
 
 |Property | Description|
 |--|--|
+|appName| Product name, default is 'Stratos' but can be changed to an arbitrary string |
 |hasEula| True if there's a EULA to show. When set to true the asset `/core/eula.html` must exist. For information about custom package assets see the images section [here](./theming#new-images).  |
 |copyright| Text shown at the bottom of the side nav|
 |logoText| Text shown with the side nav logo|


### PR DESCRIPTION
## Description
I removed a line likely left in as a debug test during development of https://github.com/cloudfoundry/stratos/pull/4842, which always set the product name on the 'About' page of Stratos to 'Zuun'.
I also took this chance to add an appropriate piece of missing documentation for the feature of being able to use angular customizations to add an arbitrary  `appName`.

## Motivation and Context
The change was mistakenly included in https://github.com/cloudfoundry-community/stratos/pull/4
Sorry for that, my bad.

## How Has This Been Tested?
I started up Stratos locally and made sure that once this line is removed, the app name defaults to Stratos.
Furthermore I also tested that if you use the Customization Service, you can put any name you want and it'll show up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message